### PR TITLE
Update logout pairings cleanup

### DIFF
--- a/src/walletConnectV2Provider.ts
+++ b/src/walletConnectV2Provider.ts
@@ -808,7 +808,7 @@ export class WalletConnectV2Provider {
 
     try {
       const inactivePairings =
-        this.walletConnector.core?.pairing?.pairings?.getAll();
+        this.walletConnector.core?.pairing?.pairings?.getAll({ active: false });
 
       if (!isValidArray(inactivePairings)) {
         return;


### PR DESCRIPTION
In v3.2.0, all pairings are removed after logging out. I think it should remove only not active pairings? 

~~Edit: After more testing, I am not sure about this. The newest Android xPortal 2.0.28 breaks the connection with my dapp (problem with the simple token, like some random string, without it, works. It can be reproduced also with [examples](https://github.com/multiversx/mx-sdk-js-examples/tree/main/signing-providers)), so hard to tell, but~~ seems to be fixed in Android xPortal 2.0.29

So, with xPortal 2.0.2 for iOS, and Android 2.0.29 when I add this change, it seems to work as previously.

Btw. v3.2.0 also has one breaking change. 
Besides this one, there is also a missing `init` in `connect`. This can break some apps that relied on init in connect.